### PR TITLE
Minor Debian packaging fixes

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kafs-client
 Section: net
 Priority: optional
 Build-Depends:
- debhelper-compat (= 12),
+ debhelper-compat (= 13),
  libkeyutils-dev,
  libkrb5-dev,
  libssl-dev,

--- a/debian/patches/0001-Remove-Makefile-rules-that-conflict-with-Debian.patch
+++ b/debian/patches/0001-Remove-Makefile-rules-that-conflict-with-Debian.patch
@@ -1,9 +1,18 @@
+From: Bill MacAllister <bill@ca-zephyr.org>
+Date: Fri, 15 May 2020 18:32:56 -0700
+Subject: Remove Makefile rules that conflict with Debian
+
 This patch is from the work of Spencer Olson <olsonse@umich.edu>.  The
 patches make builds possible using Debian package building tools.
+---
+ Makefile | 92 +---------------------------------------------------------------
+ 1 file changed, 1 insertion(+), 91 deletions(-)
 
---- kafs-client-0.3-orig/Makefile	2019-07-05 22:35:44.000000000 +0000
-+++ kafs-client-0.3/Makefile	2020-02-25 07:04:41.055636059 +0000
-@@ -18,8 +18,6 @@
+diff --git a/Makefile b/Makefile
+index ad67936..c12357d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -18,8 +18,6 @@ LNS		:= ln -sf
  #
  ###############################################################################
  VERSION		:= $(word 2,$(shell grep "^Version:" $(SPECFILE)))
@@ -12,7 +21,7 @@ patches make builds possible using Debian package building tools.
  
  ###############################################################################
  #
-@@ -42,34 +40,7 @@
+@@ -42,34 +40,7 @@ endif
  #
  ###############################################################################
  all:
@@ -48,7 +57,7 @@ patches make builds possible using Debian package building tools.
  
  ###############################################################################
  #
-@@ -82,64 +53,3 @@
+@@ -82,64 +53,3 @@ clean:
  
  distclean: clean
  	$(MAKE) -C src distclean

--- a/debian/patches/0002-Fix-location-of-kafs-dns.patch
+++ b/debian/patches/0002-Fix-location-of-kafs-dns.patch
@@ -1,6 +1,13 @@
+From: Bill MacAllister <bill@ca-zephyr.org>
+Date: Fri, 15 May 2020 18:32:56 -0700
+Subject: Fix location of kafs-dns
+
 This patch modifies the kafs_dns.conf file delivered with the package
 to match the location of the kafs-dns binary.  The location was changed
 from up stream source to match Debian common usage.
+---
+ conf/kafs_dns.conf | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/conf/kafs_dns.conf b/conf/kafs_dns.conf
 index 7e16d79..6e56e44 100644

--- a/debian/patches/0003-Fix-help-display-and-syslog-output-of-kafs-dns.patch
+++ b/debian/patches/0003-Fix-help-display-and-syslog-output-of-kafs-dns.patch
@@ -1,5 +1,12 @@
+From: Bill MacAllister <bill@ca-zephyr.org>
+Date: Fri, 15 May 2020 18:32:56 -0700
+Subject: Fix help display and syslog output of kafs-dns
+
 This patch modifies the help display and syslog output of the kafs-dns
 binary to correctly identify the binary generating the output.
+---
+ src/dns_main.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
 
 diff --git a/src/dns_main.c b/src/dns_main.c
 index 2c1e5a3..c50bf18 100644

--- a/debian/patches/0004-Allow-the-environment-to-override-CFLAGS.patch
+++ b/debian/patches/0004-Allow-the-environment-to-override-CFLAGS.patch
@@ -1,0 +1,21 @@
+From: Russ Allbery <eagle@eyrie.org>
+Date: Fri, 15 May 2020 18:53:05 -0700
+Subject: Allow the environment to override CFLAGS
+
+Do not force CFLAGS in src/Makefile and allow the environment to
+override.  This fixes discarding of hardening flags set by the
+Debian build system.
+---
+ src/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Makefile b/src/Makefile
+index 16365b7..fec80f9 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -1,4 +1,4 @@
+-CFLAGS		= -g -Wall -Wsign-compare
++CFLAGS		?= -g -Wall -Wsign-compare
+ 
+ include Makefile.config
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
-10-make.patch
-20-libexec.patch
-30-kafs-dns.patch
+0001-Remove-Makefile-rules-that-conflict-with-Debian.patch
+0002-Fix-location-of-kafs-dns.patch
+0003-Fix-help-display-and-syslog-output-of-kafs-dns.patch
+0004-Allow-the-environment-to-override-CFLAGS.patch

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,7 @@
 #!/usr/bin/make -f
 
+export DEB_BUILD_MAINT_OPTIONS = hardening=+bindnow
+
 DH_VERBOSE = 1
 
 %:


### PR DESCRIPTION
- Enable bindnow hardening
- Fix passing of hardening flags into the build
- Update to debhelper compatibility level 13
- Use `gbp pq` syntax for the patch queue